### PR TITLE
Fix for crash when a2po init

### DIFF
--- a/android2po/termcolors.py
+++ b/android2po/termcolors.py
@@ -63,7 +63,7 @@ def colorize(text='', opts=(), **kwargs):
         print colorize('and so should this')
         print 'this should not be red'
     """
-    text = str(text)
+    text = str(text.encode("utf-8"))
     code_list = []
     if text == '' and len(opts) == 1 and opts[0] == 'reset':
         return '\x1b[%sm' % RESET


### PR DESCRIPTION
Fix for this crash I experienced:

```
Traceback (most recent call last):
  File "/usr/local/bin/a2po", line 9, in <module>
    load_entry_point('android2po==1.2.dev', 'console_scripts', 'a2po')()
  File "/usr/local/lib/python2.7/dist-packages/android2po-1.2.dev-py2.7.egg/android2po/program.py", line 225, in run
    sys.exit(main(sys.argv) or 0)
  File "/usr/local/lib/python2.7/dist-packages/android2po-1.2.dev-py2.7.egg/android2po/program.py", line 216, in main
    writer.finish()
  File "/usr/local/lib/python2.7/dist-packages/android2po-1.2.dev-py2.7.egg/android2po/utils.py", line 241, in finish
    action.done('failed')
  File "/usr/local/lib/python2.7/dist-packages/android2po-1.2.dev-py2.7.egg/android2po/utils.py", line 159, in done
    self.writer._print_action(self)
  File "/usr/local/lib/python2.7/dist-packages/android2po-1.2.dev-py2.7.egg/android2po/utils.py", line 280, in _print_action
    self._print_message(m, severity)
  File "/usr/local/lib/python2.7/dist-packages/android2po-1.2.dev-py2.7.egg/android2po/utils.py", line 314, in _print_message
    **style)
  File "/usr/local/lib/python2.7/dist-packages/android2po-1.2.dev-py2.7.egg/android2po/termcolors.py", line 32, in colored
    return colorize(text, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/android2po-1.2.dev-py2.7.egg/android2po/termcolors.py", line 66, in colorize
    text = str(text)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 85: ordinal not in range(128)
```
