### PR TITLE
Added Plurals Support

### DIFF
--- a/android2po/convert.py
+++ b/android2po/convert.py
@@ -695,13 +695,17 @@ def po2xml(catalog, with_untranslated=False, filter=None, warnfunc=dummy_warn):
 
         value = message.string or message.id
 
-        if ':' in message.context:
-            # A colon indicates a string array; collect all the
-            # strings of this array with their indices, so when
-            # we're done processing the whole catalog, we can
-            # sort by index and restore the proper array order.
+        if ':quantity=' in message.context:
+            name, item = message.context.split(':quantity=', 2)
+            xml_tree.setdefault(name, {"type": "plural"})
+            if item in xml_tree[name]:
+                warnfunc(('Duplicate quantity %s in plural "%s"; ignoring '+
+                          'the message. The catalog has possibly been '+
+                          'corrupted.') % (index, name), 'error')
+            xml_tree[name][item] = value
+        elif ':' in message.context:
             name, index = message.context.split(':', 2)
-            xml_tree.setdefault(name, {})
+            xml_tree.setdefault(name, {"type": "array"})
             if index in xml_tree[name]:
                 warnfunc(('Duplicate index %s in array "%s"; ignoring '+
                           'the message. The catalog has possibly been '+
@@ -715,12 +719,21 @@ def po2xml(catalog, with_untranslated=False, filter=None, warnfunc=dummy_warn):
     namespaces_used = {}
     for name, value in xml_tree.iteritems():
         if isinstance(value, dict):
-            # string-array - first, sort by index
-            array_el = etree.Element('string-array')
-            array_el.attrib['name'] = name
-            for k in sorted(value, cmp=lambda x,y: cmp(int(x), int(y))):
-                item_el = write_to_dom('item', value[k], message, namespaces_used, warnfunc)
-                array_el.append(item_el)
+            type = value["type"]
+            del value["type"]
+            if type == "plural":
+                array_el = etree.Element('plurals')
+                array_el.attrib['name'] = name
+                for k in sorted(value):
+                    item_el = write_to_dom('item', value[k], message, namespaces_used, warnfunc)
+                    item_el.attrib["quantity"] = k
+                    array_el.append(item_el)
+            else:
+                array_el = etree.Element('string-array')
+                array_el.attrib['name'] = name
+                for k in sorted(value, cmp=lambda x,y: cmp(int(x), int(y))):
+                    item_el = write_to_dom('item', value[k], message, namespaces_used, warnfunc)
+                    array_el.append(item_el)
             root_tags.append(array_el)
         else:
             # standard string


### PR DESCRIPTION
Hey, 

I augmented the a2po script to support reading and writing of plurals.

I didn't write any unit tests , I'll leave that as an exercise for you :) but it works for our strings files just fine.

I am using the format `msgctxt "plural_name:quantity=one"` to indicate a plural vs. a string array.

Tim
