### PR TITLE
Set with_translated to True by default

### DIFF
--- a/android2po/convert.py
+++ b/android2po/convert.py
@@ -460,6 +460,8 @@ def xml2po(file, translations=None, filter=None, warnfunc=dummy_warn):
 
             for index, item in enumerate(org_value):
                 item_trans = trans_value[index].text if index < len(trans_value) else u''
+                if item.text == item_trans:
+                    item_trans = u''
 
                 # If the string has formatting markers, indicate it in the gettext output
                 flags = []
@@ -471,6 +473,9 @@ def xml2po(file, translations=None, filter=None, warnfunc=dummy_warn):
                             flags=flags, context=ctx)
 
         else:
+            if trans_value and org_value.text == trans_value.text:
+                trans_value = None
+
             # a normal string
             flags = []
 
@@ -611,7 +616,7 @@ def write_to_dom(elem_name, value, message, namespaces=None, warnfunc=dummy_warn
     return elem
 
 
-def po2xml(catalog, with_untranslated=False, filter=None, warnfunc=dummy_warn):
+def po2xml(catalog, with_untranslated=True, filter=None, warnfunc=dummy_warn):
     """Convert the gettext catalog in ``catalog`` to an XML DOM.
 
     This currently relies entirely in the fact that we can use the context


### PR DESCRIPTION
This is a patch that helped make android2po work for our workflow.
1. By setting with_untranslated to True, it fixes the issue with half-translated string-arrays being of the wrong length.
2. During export, we don't consider strings where the untranslated value equals the translated value.

I don't know how you are using android2po, but I found that these were sensible settings for our project (Astrid). In addition, we added a similar if statement to the plurals block that you can add if you decide to accept the plurals pull request.

Cheers, 

Tim
