### PR TITLE
Fix badges to point to correct repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 android2po
 ==========
 
-.. image:: https://travis-ci.org/kruton/android2po.svg?branch=master
-  :target: https://travis-ci.org/kruton/android2po
+.. image:: https://travis-ci.org/miracle2k/android2po.svg?branch=master
+  :target: https://travis-ci.org/miracle2k/android2po
 
-.. image:: https://coveralls.io/repos/kruton/android2po/badge.svg?branch=master&service=github
-  :target: https://coveralls.io/github/kruton/android2po?branch=master
+.. image:: https://coveralls.io/repos/miracle2k/android2po/badge.svg?branch=master&service=github
+  :target: https://coveralls.io/github/miracle2k/android2po?branch=master
 
 Convert Android string resources to gettext .po files, and import them
 right back.


### PR DESCRIPTION
Before this pointed to my fork of the repo, but this is incorrect now
since it's been merged upstream. This should also reveal the
problems noted in miracle2k/android2po#37.