### PR TITLE
Open file as binary since writes are encoded

### DIFF
--- a/android2po/commands.py
+++ b/android2po/commands.py
@@ -177,7 +177,7 @@ def write_file(cmd, filename, content, update=True, action=None,
 
     ensure_directories(cmd, filename.dir)
 
-    f = open(filename, 'w')
+    f = open(filename, 'wb')
     try:
         if isinstance(content, collections.Callable):
             content = content()


### PR DESCRIPTION
This fixes the breakage in Python 3.x introduced by
miracle2k/android2po#36.