### PR TITLE
Version lock lxml to 3.4.4 to fix pypy

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -2,6 +2,6 @@
 
 argparse
 babel==1.3
-lxml
+lxml==3.4.4 # 3.5.0 breaks on pypy currently
 ordereddict
 termcolor


### PR DESCRIPTION
lxml 3.5.0 apparently breaks when building with pypy, so fix it to 3.4.4
until that is fixed.