### PR TITLE
Stabilize the order of plural forms in .po files

### DIFF
--- a/android2po/env.py
+++ b/android2po/env.py
@@ -8,6 +8,8 @@ from argparse import Namespace
 from os import path
 from babel import Locale
 from babel.core import UnknownLocaleError
+
+from android2po.convert import key_plural_keywords
 from .config import Config
 from .utils import Path, format_to_re
 from .convert import read_xml, InvalidResourceError
@@ -82,8 +84,9 @@ class Language(object):
 
     @property
     def plural_keywords(self):
-        # Use .abstract rather than .rules because latter loses order
-        return [r[0] for r in self.locale.plural_form.abstract] + ['other']
+        # Sort plural rules properly
+        ret = list(self.locale.plural_form.rules.keys()) + ['other']
+        return sorted(ret, key=key_plural_keywords)
 
 
 class DefaultLanguage(Language):


### PR DESCRIPTION
Translation tools dealing with gettext files cannot provide any information on which variant corresponds to which CLDR mnemonic form. Therefore, the order of variants in gettext file is crucially important for successful translation.

Looks like locale.plural_form.abstract doesn't always follow the "canonical order" of [zero, one, two, few, many, other], and explicit sort of keys is preferable.

Here we explicitly sort plural forms and validate the "meaningfulness" of resulting .po file in tests. Tests which were relying on a different order or msgstr items are fixed.

The patch should be considered as backward-incompatible, because it breaks po -> xml transformation made in assumption of a different translation order.