### PR TITLE
Prevent KeyError: 'plural_form' if no plural form #43

### DIFF
--- a/android2po/commands.py
+++ b/android2po/commands.py
@@ -506,13 +506,18 @@ class ExportCommand(InitCommand):
 
                 # Set the correct plural forms.
                 current_plurals = lang_catalog.plural_forms
-                convert.set_catalog_plural_forms(lang_catalog, language)
-                if lang_catalog.plural_forms != current_plurals:
+                try:
+                    convert.set_catalog_plural_forms(lang_catalog, language)
+                    if lang_catalog.plural_forms != current_plurals:
+                        action.message(
+                            'The Plural-Forms header of this catalog '
+                            'has been updated to what android2po '
+                            'requires for plurals support. See the '
+                            'README for more information.', 'warning')
+                except KeyError:
                     action.message(
                         'The Plural-Forms header of this catalog '
-                        'has been updated to what android2po '
-                        'requires for plurals support. See the '
-                        'README for more information.', 'warning')
+                        'does not exist', 'warning')
 
                 # TODO: Should we include previous?
                 write_file(self, target_po,

--- a/android2po/convert.py
+++ b/android2po/convert.py
@@ -491,13 +491,17 @@ def xml2po(resources, translations=None, resfilter=None, warnfunc=dummy_warn):
     assert not translations or translations.language
 
     catalog = Catalog()
+    can_pluralise = True
     if translations is not None:
         catalog.locale = translations.language.locale
         # We cannot let Babel determine the plural expr for the locale by
         # itself. It will use a custom list of plural expressions rather
         # than generate them based on CLDR.
         # See http://babel.edgewall.org/ticket/290.
-        set_catalog_plural_forms(catalog, translations.language)
+        try:
+            set_catalog_plural_forms(catalog, translations.language)
+        except KeyError:
+            can_pluralise = False
 
     for name, org_value in resources.items():
         if resfilter and resfilter(name):
@@ -534,6 +538,8 @@ def xml2po(resources, translations=None, resfilter=None, warnfunc=dummy_warn):
                             flags=flags, context=ctx)
 
         elif isinstance(org_value, Plurals):
+            if not can_pluralise:
+                continue
             # a plurals, convert to a gettext plurals
             if len(org_value) == 0:
                 warnfunc("Warning: plurals '%s' is empty" % name, 'warning')


### PR DESCRIPTION
Catch KeyError: 'plural_form' if no plural form #43 

Not sure how to make a test for this. Works for init, export & import.
You can try it on the alarm resources at [Google source](https://android.googlesource.com/platform/packages/apps/DeskClock/+/master/res?autodive=0/) where some plurals are defined for hy-rAM and others without a default plural form.
