### PR TITLE
Various fixes for Windows / Python 3

### DIFF
--- a/android2po/commands.py
+++ b/android2po/commands.py
@@ -24,7 +24,7 @@ class CommandError(Exception):
 def read_catalog(filename, **kwargs):
     """Helper to read a catalog from a .po file.
     """
-    f = open(filename, 'r')
+    f = open(filename, 'r', encoding='utf-8')
     try:
         return pofile.read_po(f, **kwargs)
     finally:

--- a/android2po/program.py
+++ b/android2po/program.py
@@ -63,8 +63,15 @@ def parse_args(argv):
         group = cmd_parser.add_argument_group('command arguments')
         cmdclass.setup_arg_parser(group)
 
-    return parser.parse_args(argv[1:])
+    options = parser.parse_args(argv[1:])
 
+    # Stop immediately if we are called without any options (as
+    # there is no default command) else return the parsed options.
+    if options.command is None:
+        parser.print_usage()
+        sys.exit(0)
+    else:
+        return options
 
 def read_config(file):
     """Read the config file in ``file``.

--- a/android2po/utils.py
+++ b/android2po/utils.py
@@ -217,13 +217,17 @@ class Writer():
         self.verbosity = verbosity
         self.erroneous = False
 
-        # Create a codec writer wrapping stdout
-        isatty = sys.stdout.isatty() \
-            if hasattr(sys.stdout, 'isatty') else False
-        self.stdout = codecs.getwriter(
-            sys.stdout.encoding
-                if isatty
-                else locale.getpreferredencoding())(sys.stdout)
+        # sys.stdout is in text mode by default in Python 3.
+        # Create a codec writer wrapping stdout only for Python 2.
+        if sys.version_info.major < 3:
+            isatty = sys.stdout.isatty() \
+                if hasattr(sys.stdout, 'isatty') else False
+            self.stdout = codecs.getwriter(
+                sys.stdout.encoding
+                    if isatty
+                    else locale.getpreferredencoding())(sys.stdout)
+        else:
+            self.stdout = sys.stdout
 
     def action(self, event, *a, **kw):
         action = Writer.Action(self, *a, **kw)

--- a/android2po/utils.py
+++ b/android2po/utils.py
@@ -9,7 +9,7 @@ except ImportError:  # pragma: no cover
    import md5
 from os import path
 from termcolor import colored
-
+import colorama
 
 __all__ = ('Path', 'Writer', 'file_md5', 'format_to_re',)
 
@@ -212,6 +212,7 @@ class Writer():
             return sev
 
     def __init__(self, verbosity=LEVELS['default']):
+        colorama.init()
         self._current_action = None
         self._pending_actions = []
         self.verbosity = verbosity

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(name='android2po',
       license='BSD',
       packages=['android2po'],
       package_dir = {'android2po': 'android2po'},
-      install_requires = ['lxml', 'argparse', 'babel'],
+      install_requires = ['lxml', 'argparse', 'babel', 'termcolor', 'colorama'],
       **kw
       )


### PR DESCRIPTION
I discovered this project after I volunteered to translate the (open source) [PasswdSafe app](https://sourceforge.net/projects/passwdsafe/). Unfortunately, it didn't work at all - various errors. The commits in this pull request turns it into a working program again. Thx for creating it!

I have tested my work on Windows using Python 3.6.4. I'm using:

```
babel (2.5.3)
colorama (0.3.9)
lxml (4.1.1)
termcolor (1.1.0)
```
without problems. I didn't update requirements.pip, but I think the version lock for babel and lxml should be removed.

