### PR TITLE
Python 2 fixes: Using open from io package to support encoding

### DIFF
--- a/android2po/commands.py
+++ b/android2po/commands.py
@@ -6,6 +6,7 @@ try:
     from cStringIO import StringIO as BytesIO
 except ImportError:  # pragma: no cover
     from io import BytesIO
+from io import open
 from lxml import etree
 from babel.messages import pofile, Catalog
 from termcolor import colored

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,7 +1,8 @@
 # Install using pip install -r requirements.pip
 
 argparse
-babel==1.3
-lxml==3.4.4 # 3.5.0 breaks on pypy currently
+babel
+colorama
+lxml
 ordereddict
 termcolor


### PR DESCRIPTION
Also updated requirements.php - removing version locks and added
colorama. The program should work on Python 2.6 and newer.

---

The fix was needed after the Python 3 fixes in last pull request. 
Tested on Python 2.7 on Linux.