### PR TITLE
A couple changes to get builds and tests working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
+sudo: false
+
 language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "pypy3.5"
 
 cache:
   pip: true
@@ -6,17 +13,5 @@ cache:
   - .tox
   - $HOME/.cache/pip
 
-sudo: false
-
-env:
-- TOXENV=py26
-- TOXENV=py27
-- TOXENV=py33
-- TOXENV=py34
-- TOXENV=pypy
-- TOXENV=cover
-
-install:
-- pip install tox
-
+install: pip install tox-travis
 script: tox

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,7 +1,7 @@
 # Install using pip install -r requirements.pip
 
 argparse
-babel
+babel>=2.4.0
 colorama
 lxml
 ordereddict

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy,cover
+envlist = py27,py35,py36,pypy,pypy3,cover
 
 [testenv]
 deps = -r{toxinidir}/requirements.pip
        -r{toxinidir}/test-requirements.pip
 
 commands = nosetests
+
+[travis]
+python =
+  3.5: py35, cover
 
 [testenv:cover]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
Drop support for Python 2.6 and Python 3.4 and update the tests to work with Babel 2.40 and above.