### PR TITLE
Fix open mode, so it works

### DIFF
--- a/android2po/program.py
+++ b/android2po/program.py
@@ -98,7 +98,7 @@ def read_config(file):
     else:
         # Open the config file and read the arguments.
         filename = file
-        f = open(file, 'rb')
+        f = open(file, 'r')
         try:
             lines = f.readlines()
         finally:


### PR DESCRIPTION
Previously, the configuration file was being opened in bytes mode:

`open(file,` 'rb')`

This was wrong, it caused the script to crash, and throw related errors - for example:

`TypeError: startswith first arg must be bytes or a tuple of bytes, not str`

 It is now read as a string, and the script works correctly.