### PR TITLE
Force 2 space indents to be 4 spaces

### DIFF
--- a/android2po/commands.py
+++ b/android2po/commands.py
@@ -9,7 +9,6 @@ except ImportError:  # pragma: no cover
 from io import open
 from lxml import etree
 from babel.messages import pofile, Catalog
-#from elementtree import ElementTree
 from termcolor import colored
 
 from . import convert

--- a/android2po/commands.py
+++ b/android2po/commands.py
@@ -9,6 +9,7 @@ except ImportError:  # pragma: no cover
 from io import open
 from lxml import etree
 from babel.messages import pofile, Catalog
+#from elementtree import ElementTree
 from termcolor import colored
 
 from . import convert
@@ -50,8 +51,23 @@ def xml2string(tree, action):
     """
     ENCODING = 'utf-8'
     dom = convert.write_xml(tree, warnfunc=action.message)
-    return etree.tostring(dom, xml_declaration=True,
-                          encoding=ENCODING, pretty_print=True).decode('utf-8')
+
+    # By default lxml's pretty print uses 2 spaces to indent. There's no way to
+    # change this without manually adding more spaces line by line.
+    lines = etree.tostring(dom, xml_declaration=True, encoding=ENCODING,
+        pretty_print=True).decode(ENCODING).split("\n")
+
+    for i in range(len(lines)):
+        line = lines[i]
+        new_line = ""
+        for j in range(0, len(line), 2):
+            if line[j:j + 2] == "  ":
+                new_line += "  "
+            else:
+                new_line += line[j:]
+                break
+        lines[i] = new_line
+    return "\n".join(lines)
 
 
 def read_xml(action, filename, **kw):


### PR DESCRIPTION
a little proof of concept I did today:

android2po does 2 space indentation in xml files and there's no way to configure it otherwise.
this is a limitation of the lxml library used.
android studio's default is 4 spaces, which can get tricky when working with a lot of people on a single project and trying to keep git history clean

the only way to add more spaces sadly is by processing the text line by line. But it works as demonstrated in this PR.

I would not merge this pull request just yet, but I'm hoping other people might find this code useful or suggestions are made to make this more configurable.