### PR TITLE
Now emits empty item tags within a string-array

### DIFF
--- a/android2po/convert.py
+++ b/android2po/convert.py
@@ -74,7 +74,7 @@ class Plurals(dict): pass
 Translation = namedtuple('Translation', ['text', 'comments', 'formatted'])
 
 
-def get_element_text(tag, name, warnfunc=dummy_warn):
+def get_element_text(tag, name, warnfunc=dummy_warn, allow_empty=False):
     """Return a tuple of the contents of the lxml ``element`` with the
     Android specific stuff decoded and whether the text includes
     formatting codes.
@@ -327,7 +327,8 @@ def get_element_text(tag, name, warnfunc=dummy_warn):
     # unlikely that other tools would have problems, so it's for the better
     # in any case.
     if value == '':
-        raise UnsupportedResourceError('empty resources not supported')
+        if not allow_empty:
+            raise UnsupportedResourceError('empty resources not supported')
     return value, formatted
 
 
@@ -398,7 +399,7 @@ def read_xml(xml_file, language=None, warnfunc=dummy_warn):
             result[name] = StringArray()
             for child in tag.findall('item'):
                 try:
-                    text, formatted = get_element_text(child, name, warnfunc)
+                    text, formatted = get_element_text(child, name, warnfunc, allow_empty=True)
                 except UnsupportedResourceError as e:
                     # XXX: We currently can't handle this, because even if
                     # we write out a .po file with the proper array

--- a/tests/convert/test_special.py
+++ b/tests/convert/test_special.py
@@ -179,7 +179,8 @@ class TestAndroidResourceReferences(Xml2PoTest):
 
 
 def test_empty_resources():
-    """Empty resources are removed and not included in a catalog.
+    """Empty string resources are removed and not included in a catalog.
+       Empty string array items are included to maintain alignment.
     """
     catalog, logs = Xml2PoTest.make('foo', '     ')
     assert len(catalog) == 0
@@ -190,12 +191,13 @@ def test_empty_resources():
             <string-array name="test">
                 <item></item>
                 <item>          </item>
+                <item/>
+                <item>valid string</item>
             </string-array>
         </resources>
     ''')
-    assert len(catalog) == 0
-    assert 'empty' in logs[0]
-    assert 'empty' in logs[1]
+    assert len(catalog) == 4
+    assert po2xml(catalog) == {'test': [None, None, None, 'valid string']}
 
 
 class TestComments:


### PR DESCRIPTION
It is acceptable for a string-array to contain
  \<item\>\</item\>
or
 \<item/\>

These empty items may be placeholders to allow enumerations to
align with status strings. Omitting the empty items causes any
subsequent items to correspond to the wrong index.

Changed so empty items are emitted in the original location.

Bug:64