### PR TITLE
Add mapping for id (in), he (iw), yi (ji)

### DIFF
--- a/android2po/env.py
+++ b/android2po/env.py
@@ -29,11 +29,21 @@ class IncompleteEnvironment(EnvironmentError):
 
 ANDROID_LOCALE_MAPPING = {
     'from': {
+        'in_ID': 'id_ID',
+        'in': 'id',
+        'iw_IL': 'he_IL',
+        'iw': 'he',
+        'ji': 'yi',
         'zh_CN': 'zh_Hans_CN',
         'zh_HK': 'zh_Hant_HK',
         'zh_TW': 'zh_Hant_TW'
     },
     'to': {
+        'id': 'in',
+        'id_ID': 'in_ID',
+        'he': 'iw',
+        'he_IL': 'iw_IL',
+        'yi': 'ji',
         'zh_Hans_CN': 'zh_CN',
         'zh_Hant_HK': 'zh_HK',
         'zh_Hant_TW': 'zh_TW'


### PR DESCRIPTION
Those languages use a different code in Android (due to the Java roots)
then in gettext/babel, so they need to be taken care of through the
existing mapping table.

Closes #50.