### PR TITLE
Fix Callable exception in new versions of Python

### DIFF
--- a/android2po/commands.py
+++ b/android2po/commands.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import os
 import collections
+collections.Callable = collections.abc.Callable
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:  # pragma: no cover


### PR DESCRIPTION
Fix the problem below in never versions of Python. 

If you can please merge this and do a release. Thanks

 File "/usr/local/bin/a2po", line 8, in <module>
    sys.exit(run())
  File "/usr/local/lib/python3.10/site-packages/android2po/program.py", line 234, in run
    sys.exit(main(sys.argv) or 0)
  File "/usr/local/lib/python3.10/site-packages/android2po/program.py", line 222, in main
    command_result = cmd.execute()
  File "/usr/local/lib/python3.10/site-packages/android2po/commands.py", line 422, in execute
    if self.generate_po(target_po, template_data, action,
  File "/usr/local/lib/python3.10/site-packages/android2po/commands.py", line 342, in generate_po
    return write_file(self, target_po_file, content=make_catalog,
  File "/usr/local/lib/python3.10/site-packages/android2po/commands.py", line 183, in write_file
    if isinstance(content, collections.Callable):
AttributeError: module 'collections' has no attribute 'Callable'
