### PR TITLE
Fix testing: add flush() to the Tee class

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -59,6 +59,10 @@ class Tee(object):
             else:
                 f.write(data.decode('UTF-8'))
 
+    def flush(self):
+        for f in self.args:
+            f.flush()
+
 
 class TempProject(object):
     """Represents a dummy-Android project in a temporary directory that


### PR DESCRIPTION
The Tee class is used as stdout-like object, but
it was missing the flush method. That method is called by some code which is replaced by instances of Tee, leading to errors:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "<...>/tests/test_options.py", line 94, in test_old_var_compatibility
    p.program('export', {'--template': 'foobar-%s-1234.pot'})
  [...]
  File "/usr/lib/python3/dist-packages/colorama/ansitowin32.py", line 177, in write
    self.write_and_convert(text)
  File "/usr/lib/python3/dist-packages/colorama/ansitowin32.py", line 202, in write_and_convert
    self.write_plain_text(text, cursor, start)
  File "/usr/lib/python3/dist-packages/colorama/ansitowin32.py", line 211, in write_plain_text
    self.wrapped.flush()
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'Tee' object has no attribute 'flush'